### PR TITLE
Bugfix/stop running on shift key release

### DIFF
--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -96,25 +96,25 @@ void Player::handleKeyActions(GLFWwindow * window, double deltaT) {
     // Walk
     handleKeyStateChange(window, GLFW_KEY_W, isKeyPressed_W, [&]() {
         isKeyPressed_W = true;
-        (playerMovementState == PlayerMovementState::Running) ? run() : walk();
+        isKeyPressed_SHIFT ? run() : walk();
     }, [&]() {
         isKeyPressed_W = false;
     });
     handleKeyStateChange(window, GLFW_KEY_A, isKeyPressed_A, [&]() {
         isKeyPressed_A = true;
-        (playerMovementState == PlayerMovementState::Running) ? run() : walk();
+        isKeyPressed_SHIFT ? run() : walk();
     }, [&]() {
         isKeyPressed_A = false;
     });
     handleKeyStateChange(window, GLFW_KEY_S, isKeyPressed_S, [&]() {
         isKeyPressed_S = true;
-        (playerMovementState == PlayerMovementState::Running) ? run() : walk();
+        isKeyPressed_SHIFT ? run() : walk();
     }, [&]() {
         isKeyPressed_S = false;
     });
     handleKeyStateChange(window, GLFW_KEY_D, isKeyPressed_D, [&]() {
         isKeyPressed_D = true;
-        (playerMovementState == PlayerMovementState::Running) ? run() : walk();
+        isKeyPressed_SHIFT ? run() : walk();
     }, [&]() {
         isKeyPressed_D = false;
     });


### PR DESCRIPTION
- Release of the SHIFT key press is detected, and the player gets back to walking state
- SHIFT before W/A/S/D key press is now detected too, and the player starts running as expected